### PR TITLE
Add author and organization metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,8 @@ is a working reference for exactly this setup.
 behind them, the full AI cost model, CI internals, and how to extend
 the framework - written for someone who's going to build on this, not
 just run it.
+
+## Author
+
+Built by [Veeresh Bikkaneti](https://veeresh-bikkaneti.github.io/techtalkwith-veeresh/)
+at [RunTechCS](https://runtechcs.com).

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,23 @@
     <artifactId>cucumberbddparallel-parent</artifactId>
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
+    <name>cucumberBDDParallel</name>
+    <description>A Cucumber + Selenium 4 + TestNG framework for browser BDD tests, with an opt-in AI self-healing locator.</description>
+    <url>https://github.com/veeresh-bikkaneti/cucumberBDDParallel</url>
+
+    <organization>
+        <name>RunTechCS</name>
+        <url>https://runtechcs.com</url>
+    </organization>
+
+    <developers>
+        <developer>
+            <name>Veeresh Bikkaneti</name>
+            <organization>RunTechCS</organization>
+            <organizationUrl>https://runtechcs.com</organizationUrl>
+            <url>https://veeresh-bikkaneti.github.io/techtalkwith-veeresh/</url>
+        </developer>
+    </developers>
 
     <modules>
         <module>framework</module>


### PR DESCRIPTION
## Summary
- Adds `<name>`, `<description>`, `<url>`, `<organization>`, and `<developers>` to the parent `pom.xml` (inherited by both `framework` and `example-tests`).
- Adds an Author section to `README.md`.

Author: Veeresh Bikkaneti (https://veeresh-bikkaneti.github.io/techtalkwith-veeresh/)
Organization: RunTechCS (https://runtechcs.com)

## Test plan
- [x] `./mvnw -q validate` exits 0 (POM schema/XML valid)
- [x] `./mvnw -pl framework help:evaluate -Dexpression=project.organization.name -DforceStdout` prints `RunTechCS`, confirming child-module inheritance