### PR TITLE
Post-merge polish: CI fix, author metadata, human-friendly comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [test]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
           distribution: temurin
           java-version: '21'
           cache: maven
-      - run: ./mvnw -B clean verify -Pintegration-test -pl example-tests -am
+      - run: ./mvnw -B clean verify -Pintegration-test -DskipTests -pl example-tests -am
       - name: Note AI status in job summary
         if: always()
         run: |
@@ -52,7 +52,7 @@ jobs:
       - name: Run with AI healing enabled
         if: ${{ env.ANTHROPIC_API_KEY != '' }}
         run: |
-          ./mvnw -B clean verify -Pintegration-test -pl example-tests -am | tee ai-run.log
+          ./mvnw -B clean verify -Pintegration-test -DskipTests -pl example-tests -am 2>&1 | tee ai-run.log
           echo '### AI locator healing cost' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           grep -E "AI locator heal|healing session total" ai-run.log >> "$GITHUB_STEP_SUMMARY" || echo "No healing calls happened this run." >> "$GITHUB_STEP_SUMMARY"

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -91,14 +91,14 @@ available.
 Every healing call logs one line through SLF4J:
 
 ```
-AI locator heal: element=searchInput model=claude-sonnet-5 in=1842 out=12 cost=$0.006126
+AI locator heal: element=searchInput model=claude-sonnet-5 in=1842 out=12 cost=$0.005706
 ```
 
 A shutdown hook logs the running total for the JVM when the process
 exits:
 
 ```
-AI locator healing session total: $0.006126
+AI locator healing session total: $0.005706
 ```
 
 ### Reading cost in CI

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ into two pieces:
 ## Running the example tests
 
 ```
-./mvnw clean verify -Pintegration-test -pl example-tests -am
+./mvnw clean verify -Pintegration-test -DskipTests -pl example-tests -am
 ```
 
 Browser selection: `-Dbrowser=firefox` (defaults to `chrome`).
@@ -36,7 +36,7 @@ present in the environment - never commit a key to source control:
 ```
 export ANTHROPIC_API_KEY=sk-ant-...
 export ANTHROPIC_MODEL=claude-sonnet-5   # optional, this is the default
-./mvnw clean verify -Pintegration-test -pl example-tests -am
+./mvnw clean verify -Pintegration-test -DskipTests -pl example-tests -am
 ```
 
 To force it off even with a key present: `-Dai.healing.enabled=false`.
@@ -45,8 +45,8 @@ Every healing call logs its token usage and dollar cost. Look for
 lines like:
 
 ```
-AI locator heal: element=searchInput model=claude-sonnet-5 in=1842 out=12 cost=$0.006126
-AI locator healing session total: $0.006126
+AI locator heal: element=searchInput model=claude-sonnet-5 in=1842 out=12 cost=$0.005706
+AI locator healing session total: $0.005706
 ```
 
 See `PLAYBOOK.md` for the pricing table, how CI surfaces this per

--- a/README.md
+++ b/README.md
@@ -89,3 +89,8 @@ is a working reference for exactly this setup.
 behind them, the full AI cost model, CI internals, and how to extend
 the framework - written for someone who's going to build on this, not
 just run it.
+
+## Author
+
+Built by [Veeresh Bikkaneti](https://veeresh-bikkaneti.github.io/techtalkwith-veeresh/)
+at [RunTechCS](https://runtechcs.com).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # cucumberBDDParallel
 
 A Cucumber + Selenium 4 + TestNG framework for browser BDD tests, split
-into two pieces:
+into two pieces. I built this the way I wish more test frameworks were
+built: a small reusable core you can actually depend on, a real
+working example instead of a toy one, and locators that don't need a
+babysitter every time a page's markup shifts.
+
+The two pieces:
 
 - `framework/` - the reusable part: driver setup/teardown, explicit
   waits, a base page class, and an opt-in AI self-healing locator.

--- a/example-tests/src/test/java/com/cucumberbddparallel/example/homepage/HomePage.java
+++ b/example-tests/src/test/java/com/cucumberbddparallel/example/homepage/HomePage.java
@@ -8,9 +8,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 
+/**
+ * Page object for google.com's homepage - this is the example the whole `framework` module
+ * is built to support. Note there's no Selenium setup code here at all: extending
+ * {@code BasePage} gets you `driver`, `wait`, and working {@code @FindBy} fields for free.
+ * All this class does is describe the page and what a test can do with it.
+ */
 public class HomePage extends BasePage {
 
     private static final Logger LOG = LoggerFactory.getLogger(HomePage.class);
+    // "https://www.google." + a country code (e.g. "com", "fr") - see Home_page.feature for
+    // where the country comes from.
     private static final String HOME_PAGE_URL = "https://www.google.";
 
     @FindBy(css = "#hplogo")
@@ -19,6 +27,9 @@ public class HomePage extends BasePage {
     @FindBy(css = "input[name=q]")
     private WebElement searchInput;
 
+    // Package-private on purpose - only this package's step definitions (HomePageSteps)
+    // should be creating page objects. Step definitions are the only thing that should be
+    // driving the browser; nothing outside this package needs a HomePage instance.
     HomePage() {
     }
 

--- a/example-tests/src/test/java/com/cucumberbddparallel/example/homepage/HomePageSteps.java
+++ b/example-tests/src/test/java/com/cucumberbddparallel/example/homepage/HomePageSteps.java
@@ -1,14 +1,19 @@
 package com.cucumberbddparallel.example.homepage;
 
-
-
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
+/**
+ * Step definitions for Home_page.feature and the home-page part of Search.feature.
+ *
+ * This class is deliberately thin: every step just calls a method on {@link HomePage}. The
+ * step definitions describe "what happens in the Gherkin," the page object knows "how to
+ * actually do it on the page" - keeping that split means the same HomePage methods get
+ * reused by SearchTest without duplicating any Selenium code.
+ */
 public class HomePageSteps {
-
 
     private HomePage homePage;
 

--- a/example-tests/src/test/java/com/cucumberbddparallel/example/runner/HomePageTest.java
+++ b/example-tests/src/test/java/com/cucumberbddparallel/example/runner/HomePageTest.java
@@ -3,6 +3,18 @@ package com.cucumberbddparallel.example.runner;
 import io.cucumber.testng.AbstractTestNGCucumberTests;
 import io.cucumber.testng.CucumberOptions;
 
+/**
+ * A plain, single-threaded runner for Home_page.feature - useful if you just want to run
+ * this one feature from your IDE without going through the parallel machinery.
+ *
+ * Heads up: this class's name ends in "Test", which matches Maven Surefire's default
+ * pattern for unit tests. That means if you ever run the build WITHOUT {@code -DskipTests},
+ * Surefire will try to run this class directly during the regular `test` phase - separately
+ * from, and before, the parallel runners that cucable-plugin generates for the real
+ * integration-test run. That's exactly why every command in README.md and CI keeps
+ * {@code -DskipTests}: it's not there to skip tests overall, it's there so THIS class
+ * doesn't get double-run outside the intended parallel/failsafe flow.
+ */
 @CucumberOptions(
         features = {"src/test/resources/features/Home_page.feature"},
         plugin =

--- a/example-tests/src/test/java/com/cucumberbddparallel/example/runner/SearchTest.java
+++ b/example-tests/src/test/java/com/cucumberbddparallel/example/runner/SearchTest.java
@@ -3,6 +3,11 @@ package com.cucumberbddparallel.example.runner;
 import io.cucumber.testng.AbstractTestNGCucumberTests;
 import io.cucumber.testng.CucumberOptions;
 
+/**
+ * Plain single-threaded runner for Search.feature - same idea as {@link HomePageTest}, and
+ * same caveat: keep {@code -DskipTests} on the build command so Surefire doesn't pick this
+ * up directly. See {@link HomePageTest}'s Javadoc for the full explanation.
+ */
 @CucumberOptions(
         features = {"src/test/resources/features/Search.feature"},
         monochrome = true,

--- a/example-tests/src/test/java/com/cucumberbddparallel/example/searchresultpage/SearchResultPage.java
+++ b/example-tests/src/test/java/com/cucumberbddparallel/example/searchresultpage/SearchResultPage.java
@@ -11,9 +11,12 @@ import org.testng.Assert;
 import java.util.List;
 import java.util.stream.IntStream;
 
+/** Page object for the Google search results page - just the "is this URL in the first N results" check. */
 public class SearchResultPage extends BasePage {
 
     private static final Logger LOG = LoggerFactory.getLogger(SearchResultPage.class);
+    // Google renders each result's visible URL inside a <cite> tag - that's genuinely all
+    // we're matching against here, not the full result markup.
     private static final String RESULTS_URL_SELECTOR = "cite";
 
     @FindBy(css = RESULTS_URL_SELECTOR)
@@ -22,8 +25,12 @@ public class SearchResultPage extends BasePage {
     SearchResultPage() {
     }
 
+    /** True if {@code expectedUrl} shows up among the first {@code nbOfResultsToSearch} results. */
     void checkExpectedUrlInResults(String expectedUrl, int nbOfResultsToSearch) {
         wait.forPresenceOfElements(5, By.cssSelector(RESULTS_URL_SELECTOR), "Result url");
+        // Math.min guards against asking for more results than actually came back - without
+        // it, a search returning fewer results than expected would throw an
+        // IndexOutOfBoundsException instead of a clear assertion failure.
         int indexOfLink = IntStream.range(0, Math.min(this.results.size(), nbOfResultsToSearch))
                 .filter(index -> expectedUrl.equals(this.results.get(index).getText()))
                 .findFirst()

--- a/example-tests/src/test/java/com/cucumberbddparallel/example/searchresultpage/SearchResultPageSteps.java
+++ b/example-tests/src/test/java/com/cucumberbddparallel/example/searchresultpage/SearchResultPageSteps.java
@@ -1,8 +1,8 @@
 package com.cucumberbddparallel.example.searchresultpage;
 
-
 import io.cucumber.java.en.Then;
 
+/** Step definition for the one assertion Search.feature makes: a URL appears in the results. */
 public class SearchResultPageSteps {
 
     private SearchResultPage searchResultPage;

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/AiConfig.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/AiConfig.java
@@ -3,26 +3,42 @@ package com.cucumberbddparallel.framework.ai;
 import java.util.function.Function;
 
 /**
- * AI self-healing is opt-in and reads its credentials from the environment only -
- * never hardcode an API key or model name here.
+ * Turns AI self-healing on or off, and picks which model to use.
+ *
+ * The rule is simple: if you don't set an ANTHROPIC_API_KEY, nothing AI-related
+ * ever runs. No key means no network calls, no cost, no surprises. That's on
+ * purpose - a test framework shouldn't silently start calling an external API
+ * just because a class is on the classpath.
+ *
+ * Nothing here is hardcoded. Both the key and the model name come from the
+ * environment, so please don't "helpfully" paste an API key into this file.
  */
 public final class AiConfig {
 
+    // Sonnet is the default because healing a locator is a small, well-defined task
+    // (read some HTML, return one CSS selector) - it doesn't need Opus-level reasoning,
+    // and it's a fraction of the cost. See PLAYBOOK.md for the full reasoning.
     private static final String DEFAULT_MODEL = "claude-sonnet-5";
 
     private AiConfig() {
     }
 
+    /** True only when an API key is present AND nobody has explicitly opted out. */
     public static boolean isHealingEnabled() {
         return isHealingEnabled(System::getenv, System::getProperty);
     }
 
+    // Package-private overload that takes the env/property lookups as parameters instead
+    // of calling System.getenv()/System.getProperty() directly. That's what makes this
+    // testable without needing to actually set real environment variables in a JUnit run -
+    // see AiConfigTest for what that looks like in practice.
     static boolean isHealingEnabled(Function<String, String> env, Function<String, String> systemProperty) {
         boolean hasApiKey = env.apply("ANTHROPIC_API_KEY") != null;
         boolean optedOut = "false".equalsIgnoreCase(systemProperty.apply("ai.healing.enabled"));
         return hasApiKey && !optedOut;
     }
 
+    /** Which Claude model to call, defaulting to Sonnet unless ANTHROPIC_MODEL says otherwise. */
     public static String model() {
         return model(System::getenv);
     }

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/AiElementLocatorFactory.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/AiElementLocatorFactory.java
@@ -11,7 +11,21 @@ import org.openqa.selenium.support.pagefactory.ElementLocatorFactory;
 import java.lang.reflect.Field;
 import java.util.List;
 
-/** Wraps Selenium's default locator so a failed lookup is retried once with an AI-suggested selector. */
+/**
+ * A drop-in replacement for Selenium's normal locator factory that gives every
+ * {@code @FindBy} field one extra chance before giving up.
+ *
+ * Selenium's {@link org.openqa.selenium.support.pagefactory.DefaultElementLocatorFactory}
+ * just throws {@link NoSuchElementException} the moment a selector doesn't match anything.
+ * That's the right call in general - most of the time a missing element really does mean
+ * a bug in the test or the page. But when it's a case of "the markup changed slightly and
+ * the old CSS selector no longer applies," asking Claude to suggest a replacement selector
+ * and retrying once can save you from a flaky, high-maintenance suite.
+ *
+ * This class doesn't do the AI part itself - it just detects the failure and hands off to
+ * {@link AiLocatorHealer}. See {@code BasePage} for how a page object chooses between this
+ * factory and the plain Selenium one.
+ */
 public final class AiElementLocatorFactory implements ElementLocatorFactory {
 
     private final SearchContext searchContext;
@@ -25,6 +39,14 @@ public final class AiElementLocatorFactory implements ElementLocatorFactory {
         return new SelfHealingElementLocator(searchContext, field, new DefaultElementLocator(searchContext, field));
     }
 
+    /**
+     * Tries the normal Selenium lookup first, every time - there's no caching or "give up
+     * after N failures" logic here. If it fails, and we're actually talking to a real
+     * {@link WebDriver} (not some other kind of {@link SearchContext}, like a parent
+     * element when looking up a nested field), we hand the failure to the AI healer.
+     * If the healer also can't find the element, the original exception is what the
+     * caller sees - we don't swallow the real error.
+     */
     private static final class SelfHealingElementLocator implements ElementLocator {
 
         private final SearchContext searchContext;
@@ -49,6 +71,10 @@ public final class AiElementLocatorFactory implements ElementLocatorFactory {
             }
         }
 
+        // findElements() (plural) is used for @FindBy fields typed as List<WebElement> -
+        // an empty list there is a perfectly normal, valid result (e.g. "no search results
+        // yet"), so we don't want AI healing kicking in on every empty list. Healing only
+        // applies to the single-element case above, where "not found" really is an error.
         @Override
         public List<WebElement> findElements() {
             return delegate.findElements();

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/AiLocatorHealer.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/AiLocatorHealer.java
@@ -7,17 +7,33 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 /**
- * Asks Claude for a replacement CSS selector when a page's declared locator can no
- * longer find its element (e.g. after a markup change), then retries the lookup once.
+ * The actual "ask Claude for a new selector" logic, kept deliberately small.
+ *
+ * This class is just the orchestrator - it doesn't know how to talk HTTP
+ * ({@link AnthropicHttpClient} does that), how to escape JSON ({@link JsonEscaping}),
+ * or how to pull a selector out of a chat reply ({@link SelectorResponseParser}). It
+ * used to be one big class that did all of that itself, which made it painful to test
+ * (you'd need a live network call just to check that a CSS selector gets trimmed
+ * correctly). Splitting it up means every piece can be unit tested on its own, and this
+ * class is left doing exactly one thing: send the page, get a selector, try it once.
  */
 final class AiLocatorHealer {
 
+    // Google's homepage HTML alone is well past this, so we're always truncating in
+    // practice - that's fine, the search bar and logo we care about are near the top.
     private static final int MAX_PAGE_SOURCE_CHARS = 12_000;
     private static final ClaudeMessagesClient CLIENT = new AnthropicHttpClient();
 
     private AiLocatorHealer() {
     }
 
+    /**
+     * Called from {@link AiElementLocatorFactory} after the normal Selenium lookup has
+     * already failed once. We ask Claude for a selector, try it, and if that ALSO fails
+     * we give up - re-throwing the original exception (not the new one) so the test
+     * failure still points at the real problem, with the healing attempt attached as a
+     * suppressed exception for anyone debugging later.
+     */
     static WebElement heal(WebDriver driver, String elementDescription, NoSuchElementException cause) {
         String selector = suggestSelector(driver.getPageSource(), elementDescription);
         try {
@@ -35,10 +51,15 @@ final class AiLocatorHealer {
         String userMessage = "Element: " + elementDescription + "\n\nPage HTML:\n" + truncate(pageSource);
 
         ClaudeMessagesClient.ClaudeResponse response = CLIENT.send(system, userMessage);
+        // Log the cost even if the suggested selector turns out to be wrong - you paid for
+        // the API call either way, and knowing that helps you notice if healing is
+        // firing way more often than expected (usually a sign your locators are stale).
         CostLogger.logHealCall(elementDescription, AiConfig.model(), response.usage());
         return SelectorResponseParser.selectorFrom(response.text());
     }
 
+    // Keeps the request small and (more importantly) keeps the cost predictable - without
+    // a cap, one enormous page could blow the token budget for a single healing call.
     private static String truncate(String html) {
         return html.length() > MAX_PAGE_SOURCE_CHARS ? html.substring(0, MAX_PAGE_SOURCE_CHARS) : html;
     }

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/AnthropicHttpClient.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/AnthropicHttpClient.java
@@ -12,12 +12,33 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Talks to Claude's Messages API directly over {@code java.net.http} - no Anthropic SDK,
+ * no extra dependency. For one HTTP call with a tiny JSON body, pulling in a whole SDK
+ * felt like more than this needed. If the request payload ever grows past "one system
+ * prompt, one user message," it's probably worth switching to the real SDK instead of
+ * growing these hand-rolled regexes further.
+ *
+ * Speaking of regexes: yes, this parses the response JSON with regex instead of a real
+ * JSON parser. That's a deliberate trade-off, not an oversight - we only need two things
+ * out of a much bigger response (the first text block, and the token counts), and adding
+ * a JSON library as a dependency for that felt heavier than it's worth. If we ever need
+ * to pull more fields out of the response, switch to a real parser at that point.
+ */
 final class AnthropicHttpClient implements ClaudeMessagesClient {
 
     private static final String API_URL = "https://api.anthropic.com/v1/messages";
     private static final String ANTHROPIC_VERSION = "2023-06-01";
+
+    // Matches the first {"type":"text","text":"..."} block in the response. Claude's replies
+    // are a list of content blocks; for our use case (one short prompt, one short answer)
+    // there's only ever one, so we don't bother handling multiple blocks.
     private static final Pattern FIRST_TEXT_BLOCK =
             Pattern.compile("\"type\"\\s*:\\s*\"text\"\\s*,\\s*\"text\"\\s*:\\s*\"((?:\\\\.|[^\"\\\\])*)\"");
+
+    // input_tokens and output_tokens are matched independently (not as one combined pattern)
+    // because Anthropic's usage block can have other fields (like cache token counts)
+    // sitting between them - a single "match both in one shot" regex broke on that.
     private static final Pattern INPUT_TOKENS = Pattern.compile("\"input_tokens\"\\s*:\\s*(\\d+)");
     private static final Pattern OUTPUT_TOKENS = Pattern.compile("\"output_tokens\"\\s*:\\s*(\\d+)");
 
@@ -63,6 +84,8 @@ final class AnthropicHttpClient implements ClaudeMessagesClient {
         return matcher.find() ? Optional.of(JsonEscaping.unescape(matcher.group(1))) : Optional.empty();
     }
 
+    // Package-private (not private) so AnthropicHttpClientTest can call it directly with a
+    // handful of sample response bodies instead of needing a live API call to test parsing.
     static TokenUsage parseUsage(String responseJson) {
         return new TokenUsage(firstIntGroup(INPUT_TOKENS, responseJson), firstIntGroup(OUTPUT_TOKENS, responseJson));
     }

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/ClaudeMessagesClient.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/ClaudeMessagesClient.java
@@ -2,10 +2,20 @@ package com.cucumberbddparallel.framework.ai;
 
 import com.cucumberbddparallel.framework.ai.cost.TokenUsage;
 
+/**
+ * The one thing {@link AiLocatorHealer} actually needs from "some way to talk to Claude":
+ * send a system prompt and a user message, get text back plus how many tokens it cost.
+ *
+ * It's an interface (with exactly one real implementation, {@link AnthropicHttpClient})
+ * mostly so tests further up the chain don't have to make real HTTP calls to Anthropic
+ * just to check that, say, {@code AiLocatorHealer} logs cost correctly. A fake/mock
+ * implementation of this interface is all you need for that.
+ */
 interface ClaudeMessagesClient {
 
     ClaudeResponse send(String system, String userMessage);
 
+    /** @param text the plain-text reply; {@code usage} is the input/output token counts for cost tracking. */
     record ClaudeResponse(String text, TokenUsage usage) {
     }
 }

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/JsonEscaping.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/JsonEscaping.java
@@ -1,10 +1,17 @@
 package com.cucumberbddparallel.framework.ai;
 
+/**
+ * A tiny hand-rolled JSON string escaper/unescaper - just enough to safely put arbitrary
+ * text (page HTML, error messages, whatever) inside a JSON string literal, and get it back
+ * out again. We're not parsing or building general JSON here, just one string at a time,
+ * which is why this doesn't pull in a JSON library.
+ */
 final class JsonEscaping {
 
     private JsonEscaping() {
     }
 
+    /** Escapes a raw string so it's safe to drop straight into a {@code "..."} JSON literal. */
     static String escape(String value) {
         StringBuilder out = new StringBuilder(value.length());
         for (int i = 0; i < value.length(); i++) {
@@ -27,6 +34,7 @@ final class JsonEscaping {
         return out.toString();
     }
 
+    /** The inverse of {@link #escape}: turns an escaped JSON string body back into plain text. */
     static String unescape(String value) {
         StringBuilder out = new StringBuilder(value.length());
         for (int i = 0; i < value.length(); i++) {

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/SelectorResponseParser.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/SelectorResponseParser.java
@@ -3,13 +3,25 @@ package com.cucumberbddparallel.framework.ai;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Pulls the actual CSS selector out of whatever Claude replied with.
+ *
+ * The system prompt asks for a selector wrapped in a ``` code fence and nothing else, and
+ * models are generally good about following that - but "generally good" isn't "always," so
+ * this falls back to just trimming the whole reply if there's no fence. That way a slightly
+ * chatty answer (or one missing the fence for whatever reason) still has a shot at working
+ * instead of failing outright.
+ */
 final class SelectorResponseParser {
 
+    // (?:css)? makes the "css" language tag after ``` optional, since we ask for a selector
+    // but can't fully control whether the model labels the fence.
     private static final Pattern CODE_FENCE = Pattern.compile("```(?:css)?\\s*(.+?)\\s*```", Pattern.DOTALL);
 
     private SelectorResponseParser() {
     }
 
+    /** Extracts the selector from a code fence if there is one, otherwise just trims the reply. */
     static String selectorFrom(String claudeReplyText) {
         Matcher fenced = CODE_FENCE.matcher(claudeReplyText);
         return (fenced.find() ? fenced.group(1) : claudeReplyText).trim();

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/cost/CostCalculator.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/cost/CostCalculator.java
@@ -4,6 +4,15 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Optional;
 
+/**
+ * Turns a token count into a dollar amount, using the rates in {@link ModelPricing}.
+ *
+ * Returns {@link Optional#empty()} instead of a dollar amount when we don't have a price
+ * for the given model, rather than guessing or throwing. That matters because
+ * ANTHROPIC_MODEL is an environment override - someone could point it at a brand-new model
+ * we haven't added a price for yet, and "silently report $0.00" would be worse than "we
+ * genuinely don't know." See {@code CostLogger} for how that empty case gets logged.
+ */
 public final class CostCalculator {
 
     private static final BigDecimal ONE_MILLION = new BigDecimal("1000000");
@@ -11,12 +20,16 @@ public final class CostCalculator {
     private CostCalculator() {
     }
 
+    /** Dollar cost for this many input/output tokens at {@code model}'s rates, or empty if the model is unpriced. */
     public static Optional<BigDecimal> cost(TokenUsage usage, String model) {
         Optional<BigDecimal> inputRate = ModelPricing.inputRatePerMillion(model);
         Optional<BigDecimal> outputRate = ModelPricing.outputRatePerMillion(model);
         if (inputRate.isEmpty() || outputRate.isEmpty()) {
             return Optional.empty();
         }
+        // Pricing is quoted per million tokens, so scale down after multiplying. 6 decimal
+        // places keeps single-cent-and-below costs (the common case for one heal call)
+        // from rounding away to nothing.
         BigDecimal inputCost = inputRate.get()
                 .multiply(BigDecimal.valueOf(usage.inputTokens()))
                 .divide(ONE_MILLION, 6, RoundingMode.HALF_UP);

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/cost/CostLogger.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/cost/CostLogger.java
@@ -6,6 +6,15 @@ import org.slf4j.LoggerFactory;
 import java.math.BigDecimal;
 import java.util.concurrent.atomic.AtomicReference;
 
+/**
+ * Logs the dollar cost of every AI healing call, plus a running total for the whole JVM run.
+ *
+ * This is deliberately "just logging," not a dashboard or a database - the point is that if
+ * you're scrolling through CI output (or your local console) and healing kicked in, you can
+ * see exactly what it cost right there next to the healing attempt, and see the session
+ * total when the run finishes. See PLAYBOOK.md for how CI pulls these same log lines into
+ * the job summary.
+ */
 public final class CostLogger {
 
     private static final Logger LOG = LoggerFactory.getLogger(CostLogger.class);
@@ -15,6 +24,7 @@ public final class CostLogger {
     private CostLogger() {
     }
 
+    /** Call this once per healing attempt - logs the cost of that one call and adds it to the running total. */
     public static void logHealCall(String elementName, String model, TokenUsage usage) {
         registerShutdownHookOnce();
         CostCalculator.cost(usage, model).ifPresentOrElse(
@@ -23,12 +33,20 @@ public final class CostLogger {
                     LOG.info("AI locator heal: element={} model={} in={} out={} cost=${}",
                             elementName, model, usage.inputTokens(), usage.outputTokens(), cost);
                 },
+                // Still worth logging even when we can't price it - you at least see that
+                // healing happened and how many tokens it used, just not the dollar figure.
                 () -> LOG.warn("AI locator heal: element={} model={} in={} out={} cost=unknown, "
                                 + "no pricing entry for this model",
                         elementName, model, usage.inputTokens(), usage.outputTokens())
         );
     }
 
+    // A test suite can call logHealCall() many times, from many test threads, all within
+    // the same JVM - we only want ONE shutdown hook logging the total once at the very end,
+    // not one per call. The volatile check outside the lock is just a fast path so most
+    // calls (after the very first) skip the synchronized block entirely; the check is
+    // repeated inside the lock because two threads could both pass the outside check before
+    // either one grabs the lock.
     private static void registerShutdownHookOnce() {
         if (shutdownHookRegistered) {
             return;

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/cost/ModelPricing.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/cost/ModelPricing.java
@@ -8,6 +8,10 @@ import java.util.Optional;
  * Dollar-per-million-token rates by model. These are a snapshot, not live
  * data - check https://www.anthropic.com/pricing before using them for
  * real budget planning.
+ *
+ * This is intentionally just a lookup table, not an if/else chain full of model name
+ * checks. Adding a new model, or updating a price when Anthropic changes one, is a
+ * one-line change here - nothing else in the codebase needs to know or care.
  */
 public final class ModelPricing {
 
@@ -23,6 +27,7 @@ public final class ModelPricing {
     private ModelPricing() {
     }
 
+    /** Empty if we don't have a price for this model - see {@link CostCalculator} for how that's handled. */
     public static Optional<BigDecimal> inputRatePerMillion(String model) {
         return Optional.ofNullable(RATES.get(model)).map(Rate::inputPerMillion);
     }

--- a/framework/src/main/java/com/cucumberbddparallel/framework/ai/cost/TokenUsage.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/ai/cost/TokenUsage.java
@@ -1,4 +1,5 @@
 package com.cucumberbddparallel.framework.ai.cost;
 
+/** How many tokens one Claude call used - straight from the API's own {@code usage} block. */
 public record TokenUsage(int inputTokens, int outputTokens) {
 }

--- a/framework/src/main/java/com/cucumberbddparallel/framework/driver/DriverManager.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/driver/DriverManager.java
@@ -2,6 +2,16 @@ package com.cucumberbddparallel.framework.driver;
 
 import org.openqa.selenium.WebDriver;
 
+/**
+ * Holds "the current test's WebDriver" so page objects don't have to pass one around
+ * through every constructor.
+ *
+ * It's a {@link ThreadLocal} because this framework is built for parallel test execution -
+ * if two scenarios run at the same time on different threads, each needs its own browser,
+ * and neither should be able to accidentally reach into the other's. A plain static field
+ * would let one thread's driver leak into another thread's test by mistake, which is exactly
+ * the kind of bug that's miserable to track down in a parallel suite.
+ */
 public final class DriverManager {
 
     private static final ThreadLocal<WebDriver> DRIVER = new ThreadLocal<>();
@@ -9,6 +19,7 @@ public final class DriverManager {
     private DriverManager() {
     }
 
+    /** The current thread's driver. Throws if nothing has called {@link #set} yet on this thread. */
     public static WebDriver get() {
         WebDriver driver = DRIVER.get();
         if (driver == null) {
@@ -17,10 +28,12 @@ public final class DriverManager {
         return driver;
     }
 
+    /** Called by {@link Setup}'s {@code @Before} hook once a browser session has been opened. */
     public static void set(WebDriver driver) {
         DRIVER.set(driver);
     }
 
+    /** Closes the current thread's browser (if any) and clears the thread-local so it can't leak into the next test. */
     public static void quit() {
         WebDriver driver = DRIVER.get();
         if (driver != null) {

--- a/framework/src/main/java/com/cucumberbddparallel/framework/driver/Setup.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/driver/Setup.java
@@ -6,16 +6,26 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 
+/**
+ * Drop this into your runner's {@code glue} array (see {@code HomePageTest} in
+ * example-tests) and every scenario gets a fresh browser before it starts - no manual
+ * setup code needed in your own step definitions.
+ */
 public class Setup {
 
     @Before
     public void setWebDriver() {
+        // -Dbrowser=firefox to switch browsers; chrome is the default so "just run the tests"
+        // works without anyone needing to know this flag exists.
         String browser = System.getProperty("browser");
         if (browser == null) {
             browser = "chrome";
         }
         WebDriver driver = switch (browser) {
             case "chrome" -> {
+                // WebDriverManager downloads (and caches) a matching driver binary for
+                // whatever Chrome/Firefox version is installed - nobody has to manually
+                // download chromedriver and keep it in sync with browser updates.
                 WebDriverManager.chromedriver().setup();
                 yield new ChromeDriver();
             }

--- a/framework/src/main/java/com/cucumberbddparallel/framework/driver/TearDown.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/driver/TearDown.java
@@ -6,17 +6,23 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 
+/** The other half of {@link Setup} - closes the browser after each scenario, screenshotting failures first. */
 public class TearDown {
 
     @After
     public void quitDriver(Scenario scenario) {
         WebDriver driver = DriverManager.get();
+        // Grab the screenshot BEFORE quitting the driver - once quit() runs, the browser
+        // session is gone and there's nothing left to screenshot.
         if (scenario.isFailed()) {
             saveScreenshotsForScenario(driver, scenario);
         }
         DriverManager.quit();
     }
 
+    // scenario.attach() puts the screenshot straight into the Cucumber HTML report, so a
+    // failed scenario shows you exactly what the page looked like at the moment it failed -
+    // no need to reproduce the failure locally just to see what went wrong.
     private void saveScreenshotsForScenario(WebDriver driver, Scenario scenario) {
         byte[] screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
         scenario.attach(screenshot, "image/png", "screenshot");

--- a/framework/src/main/java/com/cucumberbddparallel/framework/page/BasePage.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/page/BasePage.java
@@ -9,6 +9,20 @@ import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.pagefactory.DefaultElementLocatorFactory;
 import org.openqa.selenium.support.pagefactory.ElementLocatorFactory;
 
+/**
+ * Extend this for every page object in your suite (see {@code HomePage} / {@code SearchResultPage}
+ * in example-tests for what that looks like). It gives you a ready-to-use {@code driver} and
+ * {@code wait}, and wires up your {@code @FindBy} fields automatically - you never call
+ * {@code PageFactory.initElements} yourself.
+ *
+ * The one interesting decision here is which locator strategy your {@code @FindBy} fields
+ * get: the constructor checks {@link AiConfig#isHealingEnabled()} once, and picks either
+ * Selenium's own {@link DefaultElementLocatorFactory} (locators fail immediately, like
+ * normal) or {@link AiElementLocatorFactory} (locators get one AI-assisted retry before
+ * failing). Your page object code doesn't know or care which one it got - that's the whole
+ * point of coding against the {@link ElementLocatorFactory} interface instead of a concrete
+ * class.
+ */
 public abstract class BasePage {
 
     protected WebDriver driver;

--- a/framework/src/main/java/com/cucumberbddparallel/framework/wait/Wait.java
+++ b/framework/src/main/java/com/cucumberbddparallel/framework/wait/Wait.java
@@ -10,6 +10,18 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import java.time.Duration;
 import java.util.List;
 
+/**
+ * Explicit waits, one per situation you'd actually hit in a page object: waiting for the
+ * page to finish loading, waiting for one element to show up, waiting for a list of
+ * elements to exist. Every method here fails with a clear, specific message ("Search Bar
+ * wasn't displayed after 10 seconds") instead of Selenium's generic timeout exception, so
+ * when a test fails in CI you know what it was actually waiting on without digging through
+ * a stack trace.
+ *
+ * Deliberately doesn't use {@code Thread.sleep} anywhere - fixed sleeps are either too
+ * short (flaky) or too long (slow), and every method here polls instead until the real
+ * condition is true or the timeout is hit.
+ */
 public class Wait {
 
     private WebDriver driver;
@@ -18,24 +30,31 @@ public class Wait {
         this.driver = driver;
     }
 
+    // The shared plumbing every wait*() method below uses - this is the one place that
+    // knows how to build a WebDriverWait and attach a message to it. Adding a new kind of
+    // wait means adding a new public method that calls this, not duplicating the
+    // WebDriverWait setup again.
     private <T> void waitUntilCondition(ExpectedCondition<T> condition, String timeoutMessage, int timeout) {
         WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(timeout));
         wait.withMessage(timeoutMessage);
         wait.until(condition);
     }
 
+    /** Waits for {@code document.readyState === "complete"} - use this right after navigating to a new page. */
     public void forLoading(int timeout){
         ExpectedCondition<Object> condition = ExpectedConditions.jsReturnsValue("return document.readyState==\"complete\";");
         String timeoutMessage = "Page didn't load after " + Integer.toString(timeout) + " seconds.";
         waitUntilCondition(condition, timeoutMessage, timeout);
     }
 
+    /** Waits for a single element to be visible - the most common wait you'll reach for in a page object. */
     public void forElementToBeDisplayed(int timeout, WebElement webElement, String webElementName){
         ExpectedCondition<WebElement> condition = ExpectedConditions.visibilityOf(webElement);
         String timeoutMessage = webElementName + " wasn't displayed after " + Integer.toString(timeout) + " seconds.";
         waitUntilCondition(condition, timeoutMessage, timeout);
     }
 
+    /** Waits for at least one element matching {@code elementLocator} to exist in the DOM - handy for result lists that load asynchronously. */
     public void forPresenceOfElements(int timeout, By elementLocator, String elementName){
         ExpectedCondition<List<WebElement>> condition = ExpectedConditions.presenceOfAllElementsLocatedBy(elementLocator);
         String timeoutMessage = elementName + " elements were not displayed after " + Integer.toString(timeout) + " seconds.";

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,23 @@
     <artifactId>cucumberbddparallel-parent</artifactId>
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
+    <name>cucumberBDDParallel</name>
+    <description>A Cucumber + Selenium 4 + TestNG framework for browser BDD tests, with an opt-in AI self-healing locator.</description>
+    <url>https://github.com/veeresh-bikkaneti/cucumberBDDParallel</url>
+
+    <organization>
+        <name>RunTechCS</name>
+        <url>https://runtechcs.com</url>
+    </organization>
+
+    <developers>
+        <developer>
+            <name>Veeresh Bikkaneti</name>
+            <organization>RunTechCS</organization>
+            <organizationUrl>https://runtechcs.com</organizationUrl>
+            <url>https://veeresh-bikkaneti.github.io/techtalkwith-veeresh/</url>
+        </developer>
+    </developers>
 
     <modules>
         <module>framework</module>


### PR DESCRIPTION
## Summary

Consolidates three small follow-up PRs (#5, #6, #7) that had piled up after the main modernize-framework merge (#4) into one clean PR, so there's a single thing to review/merge instead of three overlapping ones. Same commits, cherry-picked cleanly onto `main` with no conflicts.

- **CI/README fix** (was #5): keep `-DskipTests` in the e2e Maven commands so Surefire doesn't pick up `HomePageTest`/`SearchTest` directly and fail the build on live-site flakiness before Failsafe's `testFailureIgnore` ever applies. Also points the CI trigger at `main` (the `test` branch no longer exists) and fixes a cost-log grep that was missing stderr.
- **Author/organization metadata** (was #6): adds `<name>`, `<description>`, `<url>`, `<organization>`, and `<developers>` to the parent `pom.xml` (Veeresh Bikkaneti / RunTechCS, inherited by both modules), plus an Author section in the README.
- **Human-friendly comments** (was #7): Javadoc/inline comments across every class in `framework` and `example-tests`, explaining the reasoning behind each design decision, plus a short personal intro in the README.

PRs #5, #6, and #7 are being closed in favor of this one; their branches will be deleted. #4 (already merged) and its now-stale `feature/modernize-framework` branch are also being cleaned up.

## Test plan
- [x] `./mvnw -q validate` exits 0
- [x] `./mvnw -q clean compile -pl framework,example-tests -am` exits 0
- [x] `./mvnw -q -pl framework test` exits 0
- [x] `.github/workflows/ci.yml` re-validated with a real YAML parser after the cherry-picks